### PR TITLE
Fix documentation URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Boilerplate for my Python projects. Using Poetry instead of setuptools.
 
 * Python 3.7, 3.8, and 3.9 supported on Linux, macOS, and Windows.
 
-📖 Full documentation: https://rp-boilerplate-python.readthedocs.io
+📖 Full documentation: https://boilerplatepython.readthedocs.io
 
 [![Github-CI][github-ci]][github-link]
 [![Coverage Status][codecov-badge]][codecov-link]
@@ -15,7 +15,7 @@ Boilerplate for my Python projects. Using Poetry instead of setuptools.
 [github-link]: https://github.com/Robpol86/boilerplatepython/actions/workflows/ci.yml
 [codecov-badge]: https://codecov.io/gh/Robpol86/boilerplatepython/branch/main/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/Robpol86/boilerplatepython
-[rtd-badge]: https://readthedocs.org/projects/rp-boilerplate-python/badge/?version=latest
-[rtd-link]: https://rp-boilerplate-python.readthedocs.io/en/latest/?badge=latest
+[rtd-badge]: https://readthedocs.org/projects/boilerplatepython/badge/?version=latest
+[rtd-link]: https://boilerplatepython.readthedocs.io/en/latest/?badge=latest
 [black-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
 [black-link]: https://github.com/ambv/black

--- a/boilerplatepython/__init__.py
+++ b/boilerplatepython/__init__.py
@@ -1,6 +1,6 @@
 """BoilerplatePython.
 
-https://rp-boilerplate-python.readthedocs.io/
+https://boilerplatepython.readthedocs.io/
 https://github.com/Robpol86/boilerplatepython
 """
 __author__ = "@Robpol86"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,5 +7,5 @@ Boilerplate for my Python projects. Using Poetry instead of setuptools.
 Project Links
 =============
 
-* Documentation: https://rp-boilerplate-python.readthedocs.io/
+* Documentation: https://boilerplatepython.readthedocs.io/
 * Source code: https://github.com/Robpol86/boilerplatepython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 
 [tool.poetry.urls]
-documentation = "https://rp-boilerplate-python.readthedocs.io"
+documentation = "https://boilerplatepython.readthedocs.io"
 repository = "https://github.com/Robpol86/BoilerplatePython"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Can't easily find where to rename read the docs urls, and default repo
name is available, so sticking to that.